### PR TITLE
fix: use MultiWriter channel for pipe and unix stream sockets

### DIFF
--- a/junction/fs/pipe.cc
+++ b/junction/fs/pipe.cc
@@ -19,7 +19,7 @@ namespace junction {
 
 namespace {
 
-using StreamPipe = WaitableChannel<ByteChannel, false>;
+using StreamPipe = WaitableChannel<ByteChannel, true>;
 using MsgPipe = WaitableChannel<MessageChannel<void>, false>;
 
 template <class Pipe>

--- a/junction/fs/pipe.h
+++ b/junction/fs/pipe.h
@@ -270,7 +270,7 @@ inline void WaitableChannel<Channel, MultiWriter>::CloseReader(PollSource *p) {
 
 }  // namespace
 
-using StreamPipe = WaitableChannel<ByteChannel, false>;
+using StreamPipe = WaitableChannel<ByteChannel, true>;
 using MsgPipe = WaitableChannel<MessageChannel<void>, false>;
 using MultiWriterMsgPipe = WaitableChannel<MessageChannel<void>, true>;
 


### PR DESCRIPTION
Switch `StreamPipe` from `WaitableChannel<ByteChannel, false>` to `WaitableChannel<ByteChannel, true>` so that writes are serialized via the `MultiWriter` spinlock path. Otherwise the reader may be blocked indefinitely.

Reproduce with: `hackbench -T -g 1 -s 1 -f 100 -l 100` (unix socket mode) or `hackbench -T -g 1 -s 1 -f 100 -l 100 -p` (pipe mode)

---

I suspect MsgPipe should also use the MultiWriter variant. If so, the MultiWriter template parameter on WaitableChannel may no longer be necessary since all instantiations would set it to true.
