### PR TITLE
Fix DoFlocks: add missing break statements for F_SETLKW and F_GETLK

### DIFF
--- a/junction/fs/file.cc
+++ b/junction/fs/file.cc
@@ -319,8 +319,10 @@ long DoFlocks(File *f, unsigned long op, struct flock *fl) {
       break;
     case F_SETLKW:
       ret = ctx.DoSet(fl, true, f);
+      break;
     case F_GETLK:
       ret = ctx.DoGet(fl, f);
+      break;
     default:
       return -EINVAL;
   }


### PR DESCRIPTION
The F_SETLKW and F_GETLK cases were missing break statements and could fall through to the default branch, resulting in -EINVAL.

While I do not currently have a concrete test case that demonstrates this issue, the control flow strongly suggests that these cases should terminate with a break.
